### PR TITLE
second kubectl proxy update

### DIFF
--- a/4/step2.md
+++ b/4/step2.md
@@ -1,16 +1,16 @@
-Let’s refresh some of the knowledge gained in the previous chapter. By default, all pods are visible only inside the cluster. To access applications from our localhost, we need to create a proxy between our machine and the Kubernetes cluster with the proxy command:
+Recall that Pods are running in an isolated, private network - so we need to proxy access
+to them so we can debug and interact with them. To do this, we'll use the `kubectl proxy` command to run a proxy in a second terminal window. Click on the command below to automatically open a new terminal and run the `proxy`:
 
-`kubectl proxy`{{execute}}
+`kubectl proxy`{{execute T2}}
 
-The _proxy_ command runs in the foreground. All future commands are run in a separate terminal. Clicking the command will open a new terminal tab.
-
-Get the name of the Pod (in a new terminal window) and store it in the POD_NAME environment variable:
+Now again, we'll get the Pod name and query that pod directly through the proxy.
+To get the Pod name and store it in the POD_NAME environment variable:
 
 `export POD_NAME=$(kubectl get pods -o go-template --template '{{range .items}}{{.metadata.name}}{{"\n"}}{{end}}')
-echo Name of the Pod: $POD_NAME`{{execute T2}}
+echo Name of the Pod: $POD_NAME`{{execute}}
 
 To see the output of our application, run a `curl` request.
 
-`curl http://localhost:8001/api/v1/proxy/namespaces/default/pods/$POD_NAME/`{{execute T2}}
+`curl http://localhost:8001/api/v1/proxy/namespaces/default/pods/$POD_NAME/`{{execute}}
 
 The url is the route to the API of the Pod.

--- a/4/step3.md
+++ b/4/step3.md
@@ -1,5 +1,5 @@
-To get logs from the container, we’ll use the `kubectl logs` command:
+Anything that the application would normally send to `STDOUT` becomes logs for the container within the Pod. We can retrieve these logs using the `kubectl logs` command:
 
-`kubectl logs $POD_NAME`{{execute T2}}
+`kubectl logs $POD_NAME`{{execute}}
 
 *Note: We don’t need to specify the container name, because we only have one container inside the pod.*

--- a/4/step4.md
+++ b/4/step4.md
@@ -1,22 +1,22 @@
-We can execute commands directly on the container. For this, we use the `exec` command and use the name of the Pod as a parameter. Let’s list the environment variables:
+We can execute commands directly on the container once the Pod is up and running.
+For this, we use the `exec` command and use the name of the Pod as a parameter. Let’s list the environment variables:
 
-`kubectl exec $POD_NAME env`{{execute T2}}
+`kubectl exec $POD_NAME env`{{execute}}
 
-Again, worth mentioning that the name of the container itself can be omitted in this case because we have only one running in the Pod.
+Again, worth mentioning that the name of the container itself can be omitted since we only have a single container in the Pod.
 
 Next let’s start a bash session in the Pod’s container:
 
-`kubectl exec -ti $POD_NAME bash`{{execute T2}}
+`kubectl exec -ti $POD_NAME bash`{{execute}}
 
 We have now an open console on the container where we run our NodeJS application.  The source code of the app is in the server.js file:
 
-`cat server.js`{{execute T2}}
+`cat server.js`{{execute}}
 
 You can check that the application is up by running a curl command:
 
-`curl localhost:8080`{{execute T2}}
+`curl localhost:8080`{{execute}}
 
 *Note: here we used localhost because we executed the command inside the NodeJS container*
 
-To close your container connection type `exit`{{execute T2}}.
-
+To close your container connection type `exit`{{execute}}.

--- a/7/step3.md
+++ b/7/step3.md
@@ -1,34 +1,33 @@
-Pods that are running inside Kubernetes are running on a private, isolated network. 
+Pods that are running inside Kubernetes are running on a private, isolated network.
 By default they are visible from other pods and services within the same kubernetes cluster, but not outside that network.
-When we use `kubectl`, we're interacting through an API endpoint to communicate with our application. 
-This is how we can deploy the application, get logs, etc.
+When we use `kubectl`, we're interacting through an API endpoint to communicate with our application.
 
 We will cover other options on how to expose your application outside the kubernetes cluster in Module 4.
 
-`kubectl` includes the ability the create a temporary, active proxy that will forward communications into the cluster-wide, private network. 
-Running the proxy will "take up a terminal window"; when it is invoked, it will report that it's forwarding traffic, but you won't otherwise see anything from the proxy command.
-The proxy is meant to be temporary only, and when you quit the command (for example, by pressing "control-C" to exit it), the proxy will stop.
+The `kubectl` command can create a proxy that will forward communications into the cluster-wide, private network. The proxy can be terminated by pressing control-C and won't show any output
+while its running.
 
-In this online tutorial, we can have multiple terminal windows open. 
-If you are doing this on your own computer with minikube, then open a second terminal window so we can run both the proxy command and other kubectl commands.
-In the terminal window that is visible we will activate the proxy, and use a second terminal to continue to use kubectl to communicate with our application. 
+We will open a second terminal window to run the proxy.
 
-`kubectl proxy`{{execute}}
+`kubectl proxy`{{execute T2}}
 
-We now have a connection between our host (the online terminal) and the Kubernetes cluster. The started proxy enables direct access to the API. 
+We now have a connection between our host (the online terminal) and the Kubernetes cluster. The  proxy enables direct access to the API from these terminals.
 
-Now we can open a second terminal window, and get the name of the Pod and store it in the POD_NAME environment variable:
+You can see all those APIs hosted through the proxy endpoint, now available at through http://localhost:8001. For example, we can query the version directly through the API using the `curl` command:
+
+`curl http://localhost:8001/version`{{execute}}
+
+The API server will automatically create an endpoint for each pod, based on the pod name, that is also accessible through the proxy.
+
+First we need to get the Pod name, and we'll store in the environment variable POD_NAME:
 
 `export POD_NAME=$(kubectl get pods -o go-template --template '{{range .items}}{{.metadata.name}}{{"\n"}}{{end}}')
-echo Name of the Pod: $POD_NAME`{{execute T2}}
+echo Name of the Pod: $POD_NAME`{{execute}}
 
-With the proxy active, we can also now use `curl` to interact with our application. 
-The API server will automatically create an endpoint for each pod, based on the pod name, that is accessible through the proxy.
+Now we can make an HTTP request to the application running in that pod:
 
-To see the output of our application, run a curl request:
-
-`curl http://localhost:8001/api/v1/proxy/namespaces/default/pods/$POD_NAME/`{{execute T2}}
+`curl http://localhost:8001/api/v1/proxy/namespaces/default/pods/$POD_NAME/`{{execute}}
 
 The url is the route to the API of the Pod.
 
-*Note: Check the top of the terminal. The last 2 commands were executed in a new tab (Terminal 2). The proxy still runs in the first tab, and this allowed our curl command to work using localhost.*
+*Note: Check the top of the terminal. The proxy was run in a new tab (Terminal 2), and the recent commands were executed the original tab (Terminal 1). The proxy still runs in the second tab, and this allowed our curl command to work using `localhost:8001`.*

--- a/7/step4.md
+++ b/7/step4.md
@@ -1,1 +1,0 @@
-#In this tutorial we deployed our first Kubernetes application, and then observed that it was running. In the next scenario we will debug our application.#


### PR DESCRIPTION
continued work to resolve https://github.com/kubernetes/kubernetes.github.io/issues/1561

 - removed unused file 7/step4.md
 - consolidated the proxy commands to run in a second terminal window,
   preserving the first for primary interactions in the tutorial
 - rephrased and collapsed the proxy explanation text to summarize it
   more effectively
