### PR TITLE
removing specific version information

### DIFF
--- a/1/step2.md
+++ b/1/step2.md
@@ -3,4 +3,4 @@ To check if kubectl is installed you can run the *kubectl version* command:
 
 `kubectl version`{{execute}}
 
-OK, kubectl is configured and we can see both the client and the server Kubernetes version: 1.5. The client version is the kubectl version; the server version is the Kubernetes version installed on the master. Here, you can also see details about the build.
+OK, kubectl is configured and we can see both the version of the client and as well as the server. The client version is the kubectl version; the server version is the Kubernetes version installed on the master. You can also see details about the build.


### PR DESCRIPTION
resolves https://github.com/kubernetes/kubernetes.github.io/issues/5863,
which arose from the underlying technology (kubectl and minikube)
getting updated at different rates at Katacoda