### PR TITLE
WIP: Add spanish localization

### DIFF
--- a/_es/1/assets/launch.sh
+++ b/_es/1/assets/launch.sh
@@ -1,0 +1,8 @@
+echo "Starting Kubernetes..."
+minikube start
+while [ `docker ps | wc -l` -eq 1 ]
+do
+  sleep 1
+done
+
+echo "Kubernetes Started"

--- a/_es/1/finish.md
+++ b/_es/1/finish.md
@@ -1,0 +1,1 @@
+# A lo largo de este tutorial, hemos desplegado un clúster de Kubernetes con minikube, verificado la versión desplegada y consultado los nodos disponibles. En el siguiente escenario desplegaremos nuestra primera aplicación. #

--- a/_es/1/index.json
+++ b/_es/1/index.json
@@ -1,0 +1,34 @@
+{
+	"pathwayTitle": "Kubernetes Bootcamp",
+	"title": "Module 1",
+	"description": "Desplegar un clúster de Kubernetes",
+	"backend": {
+		"port": 30000,
+		"imageid": "minikube"
+	},
+	"environment": {
+		"uilayout": "terminal",
+		"hideintro": false,
+		"hidefinish": false
+	},
+	"details": {
+		"steps": [{
+			"title": " Despelgar el clúster",
+			"text": "step1.md"
+		}, {
+			"title": "Versión del clúster",
+			"text": "step2.md"
+		}, {
+			"title": "Detalles del clúster",
+			"text": "step3.md"
+		}],
+		"intro": {
+			"courseData": "env-init.sh",
+			"text": "intro.md"
+		},
+		"finish": {
+			"text": "finish.md"
+		}
+	},
+	"embedded_survey_url": "https://docs.google.com/forms/d/e/1FAIpQLScMbLRAbaZ8NleOFYRrepdIwCbhClHK3abu3SgzMn1KT_H5iA/viewform?entry.434419381="
+}

--- a/_es/1/intro.md
+++ b/_es/1/intro.md
@@ -1,0 +1,4 @@
+# El objetivo de este escenario interactivo es desplegar un clúster de Kubernetes de desarrollo local utilizando minikube #
+
+El terminal que ves en pantalla es un entorno Linux preconfigurado que se puede utilizar como una consola normal (puede escribir comandos).
+Al hacer clic en los "bloques de código" seguidos del signo INTRO, se ejecutará ese comando en el terminal.

--- a/_es/1/step1.md
+++ b/_es/1/step1.md
@@ -1,0 +1,11 @@
+Ya hemos instalado minikube por ti. Comprueba que esté correctamente instalado, ejecutando el comando *minikube version*:
+
+`minikube version`{{execute}}
+
+Como hemos podido comprobar, minikube está correctamente instalado.
+
+Puedes desplegar el clúster ejecutando el comando *minikube start*:
+
+`minikube start`{{execute}}
+
+¡Genial! En estos momentos ya puede acceder a un clúster de Kubernetes desde la consola web. Minikube levantó un clúster Kubernetes de un solo nodo en una máquina virtual.

--- a/_es/1/step2.md
+++ b/_es/1/step2.md
@@ -1,0 +1,6 @@
+Para interactuar con Kubernetes a lo largo de este bootcamp, usaremos la interfaz de línea de comandos *kubectl*. Explicaremos kubectl en detalle en los siguientes módulos, pero por ahora, solo lo usaremos para consultar información del clúster.
+Para comprobar si kubectl está instalado, puede ejecutar el comando *kubectl version*:
+
+`kubectl version`{{execute}}
+
+¡Perfecto!, Kubectl está configurado y podemos ver tanto la versión del cliente como el servidor. La versión del cliente es la versión kubectl; La versión del servidor es la versión de Kubernetes instalada en el clúster. También puede se pueden ver detalles sobre la construcción del kubectl.

--- a/_es/1/step3.md
+++ b/_es/1/step3.md
@@ -1,0 +1,11 @@
+Ahora, consultarmemos información acerca del clúster ejecutando *kubectl cluster-info*:
+
+`kubectl cluster-info`{{execute}}
+
+Como podemos ver, en estos momentos hay un master en ejecución y un panel de control. El panel de control de Kubernetes le permite ver información sobre los diferentes elementos desplegados en el clúster a través de una interfaz web. De todos modos, durante este tutorial, nos enfocaremos en la línea de comandos para implementar y explorar nuestra aplicación.
+
+Para ver los nodos en el clúster, puedes ejecutar el comando *kubectl get nodes*:
+
+`kubectl get nodes`{{execute}}
+
+Este comando muestra todos los nodos disponibles para ejecutar nuestras aplicaciones. En estos momentos, solo tenemos un nodo y podemos ver que su estado está *Ready*, es decir, listo para ejecutar cargas de trabajo

--- a/_es/strings.yaml
+++ b/_es/strings.yaml
@@ -1,0 +1,3 @@
+# i18n strings for Spanish content
+continue: "Continuar"
+start_scenario: "Empezar escenario"


### PR DESCRIPTION
While we figure out how to implement multi-language support, this PR will add the Spanish localized version of the kubernetes bootcamp scenarios in the `/es/` folder.