### PR TITLE
fix module 5 step 1 to match kubectl output

### DIFF
--- a/5/step1.md
+++ b/5/step1.md
@@ -3,9 +3,11 @@ To list your deployments use the `get deployments` command:
 
 We should have 1 Pod. If not, run the command again. This shows:
 
-The DESIRED state is showing the configured number of replicas
+The READY column shows the ratio of CURRENT to DESIRED replicas
 
-The CURRENT state show how many replicas are running now
+CURRENT is the number of replicas running now
+
+DESIRED is the configured number of replicas
 
 The UP-TO-DATE is the number of replicas that were updated to match the desired (configured) state
 


### PR DESCRIPTION
`kubectl get deployments` output now looks like this:

```
$ k get deployments
NAME           READY   UP-TO-DATE   AVAILABLE   AGE
k8s-bootcamp   4/4     4            4           5h2m
```

However step #1 of module 5 referred to a DESIRED and CURRENT
column/state. These have been combined into a READY column that lists
the CURRENT/DESIRED information.

This patch updates the verbage slightly to match the kubectl output.