### PR TITLE
Add id translation for create-cluster scenario

### DIFF
--- a/_id/1/assets/launch.sh
+++ b/_id/1/assets/launch.sh
@@ -1,0 +1,8 @@
+echo "Memulai Kubernetes..."
+minikube start
+while [ `docker ps | wc -l` -eq 1 ]
+do
+  sleep 1
+done
+
+echo "Kubernetes dimulai"

--- a/_id/1/finish.md
+++ b/_id/1/finish.md
@@ -1,0 +1,1 @@
+# Selama tutorial ini, kita membuat sebuah klaster Kubernetes menggunakan minikube, dan memeriksa versi klaster dan Node yang tersedia. Pada skenario selanjutnya, kita akan men-_deploy_ aplikasi pertama kita #

--- a/_id/1/index.json
+++ b/_id/1/index.json
@@ -13,13 +13,13 @@
 	},
 	"details": {
 		"steps": [{
-			"title": "Klaster dimulai dan berjalan",
+			"title": "Memulai dan menjanlankan Klaster",
 			"text": "step1.md"
 		}, {
-			"title": "Versi klaster",
+			"title": "Melihat versi klaster",
 			"text": "step2.md"
 		}, {
-			"title": "Detail klaster",
+			"title": "Melihat detail klaster",
 			"text": "step3.md"
 		}],
 		"intro": {

--- a/_id/1/index.json
+++ b/_id/1/index.json
@@ -1,0 +1,34 @@
+{
+	"pathwayTitle": "Kubernetes Bootcamp",
+	"title": "Modul 1 - Membuat sebuah klaster Kubernetes",
+	"description": "Membuat sebuah klaster Kubernetes",
+	"backend": {
+		"port": 30000,
+		"imageid": "minikube"
+	},
+	"environment": {
+		"uilayout": "terminal",
+		"hideintro": false,
+		"hidefinish": false
+	},
+	"details": {
+		"steps": [{
+			"title": "Klaster dimulai dan berjalan",
+			"text": "step1.md"
+		}, {
+			"title": "Versi klaster",
+			"text": "step2.md"
+		}, {
+			"title": "Detail klaster",
+			"text": "step3.md"
+		}],
+		"intro": {
+			"courseData": "env-init.sh",
+			"text": "intro.md"
+		},
+		"finish": {
+			"text": "finish.md"
+		}
+	},
+	"embedded_survey_url": "https://docs.google.com/forms/d/e/1FAIpQLScMbLRAbaZ8NleOFYRrepdIwCbhClHK3abu3SgzMn1KT_H5iA/viewform?entry.434419381="
+}

--- a/_id/1/intro.md
+++ b/_id/1/intro.md
@@ -1,4 +1,4 @@
 # Tujuan dari skenario interaktif ini adalah untuk men-_deploy_ pengembangan klaster Kubernetes lokal menggunakan minikube #
 
 Terminal online merupakan pra-konfigurasi lingkungan Linux yang dapat digunakan sebagai _console_ reguler (kamu bisa mengetik perintah).
-Klik pada `blocks of code` diikuti dengan sinyal ENTER akan mengeksekusi perintah tersebut dalam terminal.
+Klik pada `blocks of code`, lalu tekan ENTER untuk mengeksekusi perintah tersebut di dalam terminal.

--- a/_id/1/intro.md
+++ b/_id/1/intro.md
@@ -1,0 +1,4 @@
+# Tujuan dari skenario interaktif ini adalah untuk men-_deploy_ pengembangan klaster Kubernetes lokal menggunakan minikube #
+
+Terminal online merupakan pra-konfigurasi lingkungan Linux yang dapat digunakan sebagai _console_ reguler (kamu bisa mengetik perintah).
+Klik pada `blocks of code` diikuti dengan sinyal ENTER akan mengeksekusi perintah tersebut dalam terminal.

--- a/_id/1/step1.md
+++ b/_id/1/step1.md
@@ -1,0 +1,11 @@
+Kita telah memasang minikube untuk kami. Periksa apakah terpasang dengan baik, dengan menjalankan perintah *minikube version*:
+
+`minikube version`{{execute}}
+
+OK, kita dapat melihat minikube tersebut terpasang.
+
+Memulai klaster, dengan menjalankan perintah *minikube start*:
+
+`minikube start`{{execute}}
+
+Bagus! Kamu sekarang mempunyai klaster Kubernetes berjalan didalam terminal online kamu. Minikube memulai mesin virtual untuk kamu, dan klaster Kubernetes sekarang berjalan pada mesin virtual tersebut.

--- a/_id/1/step1.md
+++ b/_id/1/step1.md
@@ -1,4 +1,4 @@
-Kita telah memasang minikube untuk kami. Periksa apakah terpasang dengan baik, dengan menjalankan perintah *minikube version*:
+Kita telah melakukan pemasangan minikube. Periksa apakah terpasang dengan baik, dengan menjalankan perintah *minikube version*:
 
 `minikube version`{{execute}}
 
@@ -8,4 +8,4 @@ Memulai klaster, dengan menjalankan perintah *minikube start*:
 
 `minikube start`{{execute}}
 
-Bagus! Kamu sekarang mempunyai klaster Kubernetes berjalan didalam terminal online kamu. Minikube memulai mesin virtual untuk kamu, dan klaster Kubernetes sekarang berjalan pada mesin virtual tersebut.
+Bagus! Kamu sekarang mempunyai klaster Kubernetes berjalan di dalam terminal online kamu. Minikube memulai mesin virtual untuk kamu, dan klaster Kubernetes sekarang berjalan pada mesin virtual tersebut.

--- a/_id/1/step2.md
+++ b/_id/1/step2.md
@@ -1,0 +1,6 @@
+Untuk berinteraksi dengan Kubernetes selama bootcamp ini kita akan menggunakan antarmuka baris perintah, kubectl. Kita akan menjelaskan kubectl secara detail pada modul berikutnya, namun untuk sekarang, kita akan melihat informasi klaster.
+Untuk memeriksa apakah kubectl terpasang, kamu dapat menjalankan perintah *kubectl version*:
+
+`kubectl version`{{execute}}
+
+OK, kubectl sudah dikonfigurasikan dan kita akan melihat versi klien dan juga server. Versi klien merupakan versi kubectl; versi server merupakan versi Kubernetes yang terinstall pada master. Kamu juga dapat melihat detail tentang _build_.

--- a/_id/1/step2.md
+++ b/_id/1/step2.md
@@ -1,6 +1,6 @@
-Untuk berinteraksi dengan Kubernetes selama bootcamp ini kita akan menggunakan antarmuka baris perintah, kubectl. Kita akan menjelaskan kubectl secara detail pada modul berikutnya, namun untuk sekarang, kita akan melihat informasi klaster.
-Untuk memeriksa apakah kubectl terpasang, kamu dapat menjalankan perintah *kubectl version*:
+Untuk berinteraksi dengan Kubernetes selama bootcamp ini kita akan menggunakan antarmuka baris perintah, kubectl. Kita akan menjelaskan kubectl secara detail pada modul berikutnya, namun untuk sekarang, kita akan melihat informasi klaster terlebih dahulu.
+Untuk memeriksa apakah kubectl telah terpasang, kamu dapat menjalankan perintah *kubectl version*:
 
 `kubectl version`{{execute}}
 
-OK, kubectl sudah dikonfigurasikan dan kita akan melihat versi klien dan juga server. Versi klien merupakan versi kubectl; versi server merupakan versi Kubernetes yang terinstall pada master. Kamu juga dapat melihat detail tentang _build_.
+OK, kubectl sudah dikonfigurasikan dan kita akan melihat versi klien dan juga server. Versi klien merupakan versi kubectl; versi server merupakan versi Kubernetes yang telah terinstal pada master. Kamu juga dapat melihat detail tentang _build_.

--- a/_id/1/step3.md
+++ b/_id/1/step3.md
@@ -2,9 +2,9 @@ Mari melihat detail klaster. Kita akan melakukannya dengan menjalankan *kubectl 
 
 `kubectl cluster-info`{{execute}}
 
-Selama tutorial ini, kita akan berfokus kepada baris perintah untuk men-_deploy_ dan eksplorasi aplikasi kita.
+Selama tutorial ini, kita akan fokus pada baris perintah untuk men-_deploy_ dan mengeksplorasi aplikasi kita.
 Untuk melihat Node pada klaster, jalankan perintah *kubectl get nodes*:
 
 `kubectl get nodes`{{execute}}
 
-Perintah ini memperlihatkan semua Node yang dapat digunakan untuk hos aplikasi kita. Sekarang kita hanya mempunyai 1 Node, dan kita akan melihat bahwa statusnya siap (_ready_) (siap untuk menerima aplikasi sebagai _deployment_).
+Perintah ini memperlihatkan semua Node yang dapat digunakan untuk hos aplikasi kita. Sekarang kita hanya mempunyai 1 Node, dan kita akan melihat bahwa statusnya telah siap (_ready_). Artinya, Node telah siap untuk menerima perintah untuk menjalankan aplikasi melalui _deployment_.

--- a/_id/1/step3.md
+++ b/_id/1/step3.md
@@ -1,0 +1,10 @@
+Mari melihat detail klaster. Kita akan melakukannya dengan menjalankan *kubectl cluster-info*:
+
+`kubectl cluster-info`{{execute}}
+
+Selama tutorial ini, kita akan berfokus kepada baris perintah untuk men-_deploy_ dan eksplorasi aplikasi kita.
+Untuk melihat Node pada klaster, jalankan perintah *kubectl get nodes*:
+
+`kubectl get nodes`{{execute}}
+
+Perintah ini memperlihatkan semua Node yang dapat digunakan untuk hos aplikasi kita. Sekarang kita hanya mempunyai 1 Node, dan kita akan melihat bahwa statusnya siap (_ready_) (siap untuk menerima aplikasi sebagai _deployment_).

--- a/_id/strings.yaml
+++ b/_id/strings.yaml
@@ -1,0 +1,13 @@
+# i18n strings for Spanish content
+continue: "Lanjut"
+start_scenario: "Memulai skenario"
+welcome: "Selamat datang"
+difficulty: "tingkat kesulitan"
+time: "waktu"
+steps: "langkah-langkah"
+step: "langkah"
+of: ""
+answer: "jawaban"
+solution: "solusi"
+show: "menampilkan"
+terminal: "terminal"

--- a/_id/strings.yaml
+++ b/_id/strings.yaml
@@ -1,4 +1,4 @@
-# i18n strings for Spanish content
+# i18n strings for Indonesian content
 continue: "Lanjut"
 start_scenario: "Memulai skenario"
 welcome: "Selamat datang"


### PR DESCRIPTION
This PR is part of Indonesian translation docs https://github.com/kubernetes/website/issues/22296 . It requires to translate Kubernetes first scenario in Katacoda labs ( this page `/docs/tutorials/kubernetes-basics/create-cluster/cluster-interactive/`) 😊

cc: @girikuncoro