### PR TITLE
Add new scenario for kube config and Java

### DIFF
--- a/9/assets/launch.sh
+++ b/9/assets/launch.sh
@@ -1,0 +1,3 @@
+echo "Starting Kubernetes 1.15.0. This may take a few moments, please wait..."
+while [ `minikube status &>/dev/null; echo $?` -ne 0 ]; do sleep 1; done
+echo "Kubernetes Started"

--- a/9/assets/launch.sh
+++ b/9/assets/launch.sh
@@ -1,3 +1,3 @@
-echo "Starting Kubernetes 1.15.0. This may take a few moments, please wait..."
+echo "Starting Kubernetes. This may take a few moments, please wait..."
 while [ `minikube status &>/dev/null; echo $?` -ne 0 ]; do sleep 1; done
 echo "Kubernetes Started"

--- a/9/env-init.sh
+++ b/9/env-init.sh
@@ -1,0 +1,4 @@
+git clone https://github.com/jamiecoleman92/guide-kubernetes-microprofile-config.git
+docker pull open-liberty:latest
+
+ssh root@host01 "while [ \`minikube status &>/dev/null; echo \$?\` -ne 0 ]; do sleep 1; done && kubectl run kubernetes-bootcamp --image=gcr.io/google-samples/kubernetes-bootcamp:v1 --port=8080 && echo done >> /opt/katacoda-completed"

--- a/9/finish.md
+++ b/9/finish.md
@@ -1,0 +1,8 @@
+## Great Work! You're done!
+
+You have used MicroProfile Config to externalize the configuration of two microservices, and then you configured them by creating a ConfigMap and Secret in your Kubernetes cluster.
+
+If you would like to look at the code for these microservices follow the link to the github repository. For more information about the MicroProfile specification used in this tutorial, visit the MicroProfile website with the link below.
+
+[Github repository](https://github.com/OpenLiberty/guide-kubernetes-microprofile-config)
+[MicroProfile.io](https://microprofile.io)

--- a/9/foreground.sh
+++ b/9/foreground.sh
@@ -1,0 +1,3 @@
+export JAVA_HOME=/usr/lib/jvm/java-11-openjdk-amd64/
+
+sleep 1; launch.sh

--- a/9/index.json
+++ b/9/index.json
@@ -1,0 +1,54 @@
+{
+  "title": "Configuring a Kubernetes Microservice",
+  "description": "Configure a Java Microservice using Kubernetes and MicroProfile",
+  "difficulty": "beginner",
+  "time": "15 minutes",
+  "details": {
+    "steps": [
+      {
+        "title": "",
+        "text": "step1.md",
+        "code": "foreground.sh"
+      },
+      {
+        "title": "",
+        "text": "step2.md"
+      },
+      {
+        "title": "",
+        "text": "step3.md"
+      },
+      {
+        "title": "",
+        "text": "step4.md"
+      },
+      {
+        "title": "",
+        "text": "step5.md"
+      },
+      {
+        "title": "",
+        "text": "step6.md"
+      },
+      {
+        "title": "",
+        "text": "step7.md"
+      }
+    ],
+  "intro": {
+    "text": "intro.md",
+    "courseData": "pre.sh"
+  },
+   "finish": {
+      "text": "finish.md"
+    }
+    },
+  "environment": {
+    "uilayout": "editor-terminal"
+  },
+	"backend": {
+		"port": 30000,
+		"dockerimage": "minikube-running"
+  },
+  "embedded_survey_url": "https://docs.google.com/forms/d/e/1FAIpQLScMbLRAbaZ8NleOFYRrepdIwCbhClHK3abu3SgzMn1KT_H5iA/viewform?entry.434419381="
+}

--- a/9/intro.md
+++ b/9/intro.md
@@ -1,0 +1,3 @@
+## The goal of this interactive scenario is to deploy two Java microservices to Kubernetes and change their configuration using MicroProfile Config, Kubernetes ConfigMaps and Secrets.
+
+The online terminal is a pre-configured Linux environment that can be used as a regular console (you can type commands). Clicking on the blocks of code followed by the ENTER key will execute that command in the terminal.

--- a/9/step1.md
+++ b/9/step1.md
@@ -1,0 +1,26 @@
+## Build and Deploy the Java microservices
+
+To begin, make sure your Kubernetes environment is set up. Once the terminal has finished outputting messages and is ready for input it should be setup. To confirm it is ready please run the following command:
+
+`kubectl version`{{execute}}
+
+You should now see the versions of your kubectl client and server. If so, your environment is all set up. If you do not see the version of your Kubernetes server wait a few moments and repeat the previous command until it is shown.
+
+Now you need to navigate into the project directory that has been provided for you.  This contains the implementation of the MicroProfile microservices, configuration for the MicroProfile runtime, and Kubernetes configuration.
+
+`cd guide-kubernetes-microprofile-config/start/`{{execute}}
+
+You will notice there is a 'finish' directory. This contains the finished code for this tutorial for reference.
+
+The two microservices you will deploy are called 'system' and 'inventory'. The system microservice returns JVM properties of the container it is running in. The inventory microservice adds the properties from the system microservice into the inventory. This demonstrates how communication can be achieved between two microservices in separate pods inside a Kubernetes cluster. To build the applications with Maven, run the following commands one after the other:
+
+`mvn package -pl system`{{execute}}
+
+
+`mvn package -pl inventory`{{execute}}
+
+Once the services have been built, you need to deploy them to Kubernetes. To learn more about Kubernetes manifests, check out the following documentation: https://kubernetes.io/docs/concepts/cluster-administration/manage-deployment/
+
+To do this use, the following command:
+
+`kubectl apply -f kubernetes.yaml`{{execute}}

--- a/9/step2.md
+++ b/9/step2.md
@@ -1,0 +1,31 @@
+## Making requests to the microservices
+
+The two commands below will check the status of the pods and check when they are in a ready state. This is done by providing the command with the labels for the pod such as `inventory`. Issue the following commands to check the status of your microservices:
+
+`kubectl wait --for=condition=ready pod -l app=inventory`{{execute}}
+
+
+`kubectl wait --for=condition=ready pod -l app=system`{{execute}}
+
+Once you see the output **condition met** from each of the above commands it means your microservices are ready to receive requests. 
+
+Now that your microservices are deployed and running with the **Ready** status you are ready to send some requests.
+
+
+Next, you'll use `curl` to make an `HTTP GET` request to the 'system' service. The service is secured with a user id and password that is passed in the request.
+
+`curl -u bob:bobpwd http://$( minikube ip ):31000/system/properties`{{execute}}
+
+You should see a response that will show you the JVM system properties of the running container.
+
+
+Similarly, use the following `curl` command to call the inventory service:  
+
+`curl http://$( minikube ip ):32000/inventory/systems/system-service`{{execute}}
+
+The inventory service will call the system service and store the response data in the inventory service before returning the result.
+
+In this tutorial, you're going to use a Kubernetes ConfigMap to modify the `X-App-Name:` response header. Take a look at their current values by running the following curl command:
+
+`curl -# -I -u bob:bobpwd -D - http://$( minikube ip ):31000/system/properties | grep -i ^X-App-Name:`{{execute}}
+

--- a/9/step3.md
+++ b/9/step3.md
@@ -1,0 +1,43 @@
+## Modifying the System Microservice
+
+The system service is hardcoded to have `system` as the app name. To make this configurable, you'll add the `appName` member and code to set the `X-App-Name` to the `/guide-kubernetes-microprofile-config/start/system/src/main/java/system/SystemResource.java`{{open}} file. Click on the link above to open the file and then use the Katacode text editor to replace the existing code with the following:
+
+<pre class="file" data-target="clipboard">
+package system;
+
+// CDI
+import javax.enterprise.context.RequestScoped;
+import javax.inject.Inject;
+import javax.ws.rs.GET;
+// JAX-RS
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+
+@RequestScoped
+@Path("/properties")
+public class SystemResource {
+
+  @Inject
+  @ConfigProperty(name = "APP_NAME")
+  private String appName;
+
+  @Inject
+  @ConfigProperty(name = "HOSTNAME")
+  private String hostname;
+
+  @GET
+  @Produces(MediaType.APPLICATION_JSON)
+  public Response getProperties() {
+    return Response.ok(System.getProperties())
+      .header("X-Pod-Name", hostname)
+      .header("X-App-Name", appName)
+      .build();
+  }
+}
+</pre>
+
+These changes use MicroProfile Config and CDI to inject the value of an environment variable called `APP_NAME` into the `appName` member of the `SystemResource` class.  MicroProfile Config supports a number of config sources from which to receive configuration, including environment variables. 

--- a/9/step4.md
+++ b/9/step4.md
@@ -1,0 +1,16 @@
+## Modifying the Inventory Microservice
+
+The inventory service is hardcoded to use `bob` and `bobpwd` as the credentials to authenticate against the system service. You’ll make these credentials configurable using a Kubernetes Secret. In the Katacoda text editor, open the file by clicking on the following link `/guide-kubernetes-microprofile-config/start/inventory/src/main/java/inventory/client/SystemClient.java`{{open}} and replace the two lines under `// Basic Auth Credentials` with the following
+
+<pre class="file" data-target="clipboard">
+  // Basic Auth Credentials
+  @Inject
+  @ConfigProperty(name = "SYSTEM_APP_USERNAME")
+  private String username;
+
+  @Inject
+  @ConfigProperty(name = "SYSTEM_APP_PASSWORD")
+  private String password;
+</pre>
+
+These changes use MicroProfile Config and CDI to inject the value of the environment variables `SYSTEM_APP_USERNAME` and `SYSTEM_APP_PASSWORD` into the SystemClient class.

--- a/9/step5.md
+++ b/9/step5.md
@@ -1,0 +1,17 @@
+## Creating a ConfigMap and Secret
+
+There are several ways to configure an environment variable in containers. You are going to use a Kubernetes ConfigMap and Kubernetes secret to set these values. These are resources provided by Kubernetes that are used as a way to provide configuration values to your containers. A benefit is that they can be re-used across multiple containers, including being assigned to different environment variables for the different containers.
+
+Create a ConfigMap to configure the application name with the following kubectl command:
+
+`kubectl create configmap sys-app-name --from-literal name=my-system`{{execute}}
+
+This command deploys a ConfigMap named `sys-app-name` to your cluster. It has a key called `name` with a value of `my-system`. The `--from-literal` flag allows you to specify individual key-value pairs to store in this ConfigMap. Other available options, such as `--from-file` and `--from-env-file`, provide more versatility as to how to configure. Details about these options can be found in the Kubernetes CLI documentation here https://kubernetes.io/docs/concepts/configuration/configmap/.
+
+Create a secret to configure the credentials that the inventory service will use to authenticate against system service with the following kubectl command:
+
+`kubectl create secret generic sys-app-credentials --from-literal username=bob --from-literal password=bobpwd`{{execute}}
+
+This command looks very similar to the command to create a ConfigMap, one difference is the word generic. It means that you’re creating a secret that is `generic`, which means it is not a specialized type of secret. There are different types of secrets, such as secrets to store Docker credentials and secrets to store public/private key pairs.
+
+A secret is similar to a ConfigMap, except a secret is used for sensitive information such as credentials. One of the main differences is that you have to explicitly tell kubectl to show you the contents of a secret. Additionally, when it does show you the information, it only shows you a Base64 encoded version so that a casual onlooker can't accidentally see any sensitive data. secrets don’t provide any encryption by default, that is something you’ll either need to do yourself or find an alternate option to configure.

--- a/9/step6.md
+++ b/9/step6.md
@@ -1,0 +1,96 @@
+## Updating Kubernetes resources
+
+You will now update your Kubernetes deployment to set the environment variables in your containers, based on the values configured in the ConfigMap and Secret. Edit the `kubernetes.yaml` file (located in the `start` directory). This file defines the Kubernetes deployment.  Note the `valueFrom` field. This specifies the value of an environment variable, and can be set from various sources. Sources include a ConfigMap, a Secret, and information about the cluster. In this example `configMapKeyRef` sets the key `name` with the value of the ConfigMap `sys-app-name`. Similarly, `secretKeyRef` sets the keys `username` and `password` with values from the Secret `sys-app-credentials`.
+
+Open the `/guide-kubernetes-microprofile-config/start/kubernetes.yaml`{{open}} file by clicking on the above link and replace the contents with the following:
+
+<pre class="file" data-target="clipboard">
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: system-deployment
+  labels:
+    app: system
+spec:
+  selector:
+    matchLabels:
+      app: system
+  template:
+    metadata:
+      labels:
+        app: system
+    spec:
+      containers:
+      - name: system-container
+        image: system:1.0-SNAPSHOT
+        ports:
+        - containerPort: 9080
+        # Set the APP_NAME environment variable
+        env:
+        - name: APP_NAME
+          valueFrom:
+            configMapKeyRef:
+              name: sys-app-name
+              key: name
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: inventory-deployment
+  labels:
+    app: inventory
+spec:
+  selector:
+    matchLabels:
+      app: inventory
+  template:
+    metadata:
+      labels:
+        app: inventory
+    spec:
+      containers:
+      - name: inventory-container
+        image: inventory:1.0-SNAPSHOT
+        ports:
+        - containerPort: 9080
+        # Set the SYSTEM_APP_USERNAME and SYSTEM_APP_PASSWORD environment variables
+        env:
+        - name: SYSTEM_APP_USERNAME
+          valueFrom:
+            secretKeyRef:
+              name: sys-app-credentials
+              key: username
+        - name: SYSTEM_APP_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: sys-app-credentials
+              key: password
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: system-service
+spec:
+  type: NodePort
+  selector:
+    app: system
+  ports:
+  - protocol: TCP
+    port: 9080
+    targetPort: 9080
+    nodePort: 31000
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: inventory-service
+spec:
+  type: NodePort
+  selector:
+    app: inventory
+  ports:
+  - protocol: TCP
+    port: 9080
+    targetPort: 9080
+    nodePort: 32000
+</pre>

--- a/9/step7.md
+++ b/9/step7.md
@@ -1,0 +1,44 @@
+## Deploying your changes
+
+You now need rebuild and redeploy the applications for your changes to take effect. Rebuild the application using the following commands, making sure you're in the `start` directory:
+
+`mvn package -pl system`{{execute}}
+
+`mvn package -pl inventory`{{execute}}
+
+Now you need to delete your old Kubernetes deployment then deploy your updated deployment by issuing the following commands:
+
+`kubectl replace --force -f kubernetes.yaml`{{execute}}
+
+You should see the following output from the commands:
+
+`
+$ kubectl replace --force -f kubernetes.yaml
+deployment.apps "system-deployment" deleted
+deployment.apps "inventory-deployment" deleted
+service "system-service" deleted
+service "inventory-service" deleted
+deployment.apps/system-deployment replaced
+deployment.apps/inventory-deployment replaced
+service/system-service replaced
+service/inventory-service replaced
+`
+
+Check the status of the pods for the services with:
+
+`kubectl get --watch pods`{{execute}}
+
+You should eventually see the status of **Ready** for the two services. Press `Ctrl-C` to exit the terminal command. 
+
+Call the updated system service and check the headers using the curl command:
+
+
+`curl -u bob:bobpwd -D - http://$( minikube ip ):31000/system/properties -o /dev/null`{{execute}}
+
+You should see that the response `X-App-Name` header has changed from `system` to `my-system`​.
+
+Verify that inventory service is now using the Kubernetes Secret for the credentials by making the following curl request:
+
+`curl http://$( minikube ip ):32000/inventory/systems/system-service`{{execute}}
+
+If the request fails, check you've configured the Secret correctly.


### PR DESCRIPTION
@BenHall I have changed what I have to try and replicate the environment creation the same way that other tutorials have done in this repo. Due to this, I have resulted in the following error that I presume may be a permissions issue:

"It looks like we couldn't read a file. Please check that all the files defined in index.json exist and an Environment Image ID has been defined.

Details: [ScenarioError]: Cannot access course data file alias ssh="ssh -oBatchMode=yes -o TCPKeepAlive=yes -o ServerAliveInterval=30 -o ServerAliveCountMax=30 -o ConnectTimeout=30 -o ConnectionAttempts=30 -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o LogLevel=quiet" alias scp="scp -oBatchMode=yes -o TCPKeepAlive=yes -o ServerAliveInterval=30 -o ServerAliveCountMax=30 -o ConnectTimeout=30 -o ConnectionAttempts=30 -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -o LogLevel=quiet" in jamiecoleman/kubeconfig. Does the file exist?"

The only other thing that may change is the git repo that we use for the source code of this tutorial, as this is currently in my personal account. This is referenced in the env-init.sh file. 

If the above error is not related to Kubernetes using a special account with Katacoda, then we need to find a solution to this issue before this can be merged.

The error can be found in my account and was not present before I tried to follow the Kubernetes environment setup structure shown here in this commit: https://github.com/jamiecoleman92/katacoda-scenarios/tree/799ea539c58d5239d49aa40941c05c0986a1199f

Link to my Katacoda scenario:
https://katacoda.com/jamiecoleman/scenarios/kubeconfig
