### PR TITLE
Use pods everywhere

### DIFF
--- a/8/step2.md
+++ b/8/step2.md
@@ -17,7 +17,7 @@ echo Name of the Pod: $POD_NAME`{{execute}}
 
 To apply a new label we use the label command followed by the object type, object name and the new label:
 
-`kubectl label pod $POD_NAME app=v1`{{execute}}
+`kubectl label pods $POD_NAME app=v1`{{execute}}
 
 This will apply a new label to our Pod (we pinned the application version to the Pod), and we can check it with the describe pod command:
 

--- a/_es/8/step2.md
+++ b/_es/8/step2.md
@@ -17,7 +17,7 @@ echo Name of the Pod: $POD_NAME`{{execute}}
 
 Para aplicar una nueva etiqueta, utilizamos el comando de etiqueta seguido del tipo de objeto, el nombre del objeto y la nueva etiqueta:
 
-`kubectl label pod $POD_NAME app=v1`{{execute}}
+`kubectl label pods $POD_NAME app=v1`{{execute}}
 
 Esto aplicará una nueva etiqueta a nuestro Pod (fijamos la versión de la aplicación al Pod), y podemos verificarlo con el comando `describe pod`:
 


### PR DESCRIPTION
fixes https://github.com/kubernetes/website/issues/27087

Without explanation, `pod` and `pods` are used. This PR intends to fix it as using `pods $POD_NAME` gives the same result as `pod $POD_NAME`.