### PR TITLE
Changing git repo location to a more permanent place

### DIFF
--- a/9/env-init.sh
+++ b/9/env-init.sh
@@ -1,4 +1,4 @@
-ssh root@host01 "git clone https://github.com/jamiecoleman92/guide-kubernetes-microprofile-config.git"
+ssh root@host01 "git clone https://github.com/OpenLiberty/sample-kubernetes-config.git"
 ssh root@host01 "docker pull open-liberty:latest"
 
 ssh root@host01 "while [ \`minikube status &>/dev/null; echo \$?\` -ne 0 ]; do sleep 1; done && kubectl create deployment kubernetes-bootcamp --image=gcr.io/google-samples/kubernetes-bootcamp:v1 --port=8080 && echo done >> /opt/katacoda-completed"


### PR DESCRIPTION
Changing the location to a repo under the OpenLiberty github org (https://github.com/OpenLiberty/sample-kubernetes-config/) so that it can be more easily maintained. The repo is a copy of the one in my personal org except with some changes to the readme to explain the tutorial and what it does.