### PR TITLE
Change pod to pods in module 4 step 2

### DIFF
--- a/8/step2.md
+++ b/8/step2.md
@@ -17,7 +17,7 @@ echo Name of the Pod: $POD_NAME`{{execute}}
 
 To apply a new label we use the label command followed by the object type, object name and the new label:
 
-`kubectl label pod $POD_NAME version=v1`{{execute}}
+`kubectl label pods $POD_NAME version=v1`{{execute}}
 
 This will apply a new label to our Pod (we pinned the application version to the Pod), and we can check it with the describe pod command:
 

--- a/_es/8/step2.md
+++ b/_es/8/step2.md
@@ -17,7 +17,7 @@ echo Name of the Pod: $POD_NAME`{{execute}}
 
 Para aplicar una nueva etiqueta, utilizamos el comando de etiqueta seguido del tipo de objeto, el nombre del objeto y la nueva etiqueta:
 
-`kubectl label pod $POD_NAME version=v1`{{execute}}
+`kubectl label pods $POD_NAME version=v1`{{execute}}
 
 Esto aplicará una nueva etiqueta a nuestro Pod (fijamos la versión de la aplicación al Pod), y podemos verificarlo con el comando `describe pod`:
 

--- a/_id/8/step2.md
+++ b/_id/8/step2.md
@@ -17,7 +17,7 @@ echo Name of the Pod: $POD_NAME`{{execute}}
 
 Untuk memasang label baru, kita dapat menggunakan perintah label diikuti dengan tipe objek, nama objek dan label baru tersebut:
 
-`kubectl label pod $POD_NAME version=v1`{{execute}}
+`kubectl label pods $POD_NAME version=v1`{{execute}}
 
 Perintah di atas akan memberikan label baru untuk Pod kita (menyematkan versi aplikasi kita pada Pod), dan kita dapat memastikan hal ini dengan perintah describe pod:
 


### PR DESCRIPTION
Fix for kubernetes/website#27087

Changed pod into pods for the command `kubectl label pods $POD_NAME version=v1`. The same result is achieved but the command is more consistent with the rest of the lesson. 

Commands have been changed for all languages of the tutorial.